### PR TITLE
fix syntax in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,12 +91,10 @@ function App() {
     whileElementsMounted: autoUpdate,
  
     // Or, pass options. Ensure the cleanup function is returned.
-    useFloating(reference, floating, {
-      whileElementsMounted: (reference, floating, update) =>
-        autoUpdate(reference, floating, update, {
-          animationFrame: true,
-        }),
-    });
+    whileElementsMounted: (reference, floating, update) =>
+      autoUpdate(reference, floating, update, {
+        animationFrame: true,
+      }),
   });
 }
 ```

--- a/README.md
+++ b/README.md
@@ -91,10 +91,11 @@ function App() {
     whileElementsMounted: autoUpdate,
  
     // Or, pass options. Ensure the cleanup function is returned.
-    whileElementsMounted: (reference, floating, update) =>
+    whileElementsMounted: (reference, floating, update) => (
       autoUpdate(reference, floating, update, {
         animationFrame: true,
-      }),
+      })
+    )
   });
 }
 ```

--- a/README.md
+++ b/README.md
@@ -91,11 +91,12 @@ function App() {
     whileElementsMounted: autoUpdate,
  
     // Or, pass options. Ensure the cleanup function is returned.
-    whileElementsMounted: (reference, floating, update) => (
-      autoUpdate(reference, floating, update, {
-        animationFrame: true,
-      }),
-    )
+    useFloating(reference, floating, {
+      whileElementsMounted: (reference, floating, update) =>
+        autoUpdate(reference, floating, update, {
+          animationFrame: true,
+        }),
+    });
   });
 }
 ```


### PR DESCRIPTION
There's a comma here that breaks the syntax, and gives "Expression expected.ts(1109)"

<img width="455" alt="Screenshot 2025-01-20 at 13 46 04" src="https://github.com/user-attachments/assets/b5bd8a28-6aa1-489a-b081-6a2f5dbbd60a" />
